### PR TITLE
chore(dependabot): customize os revisores e mensagem de commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    assignees:
+      - "renebentes"
+    reviewers:
+      - "renebentes"
+      - "copilot"
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
Este PR configura as opções de revisores e mensagem de commits para o dependabot