### PR TITLE
revert: chore(dependabot): customize os revisores e mensagem de commit (#21)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @renebentes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,3 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    assignees:
-      - "renebentes"
-    reviewers:
-      - "renebentes"
-      - "copilot"
-    commit-message:
-      prefix: "build"
-      include: "scope"


### PR DESCRIPTION
Esta alteração foi revertida porque não houve ganho real e, agora, os revisores são configurados a partir do arquivo CODEOWNERS, o que é mais simples e eficaz.

This reverts commit a0466771874cf19d66187e0d88f7340a90be5d5f.