### PR TITLE
ci(dependabot): altere as configurações

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,8 @@ updates:
   - package-ecosystem: nuget
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
O dependabot foi configurado para executar semanalmente e adicionamos um prefixo às suas mensagens de commit