### PR TITLE
test: substitua FluentAssertions por Shouldly

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="FluentAssertions" Version="8.3.0" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
@@ -21,6 +20,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.13.1" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.13.1" />
+    <PackageVersion Include="Shouldly" Version="4.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageVersion Include="xunit.v3" Version="2.0.3" />

--- a/tests/Dima.UnitTests/Api/Categories/CreateCategoryHandlerTests.cs
+++ b/tests/Dima.UnitTests/Api/Categories/CreateCategoryHandlerTests.cs
@@ -36,18 +36,15 @@ public sealed class CreateCategoryHandlerTests
 
         // Assert
         result
-            .Should()
-            .NotBeNull();
+            .ShouldNotBeNull();
 
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
 
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Created);
+            .ShouldBe(ResultStatus.Created);
     }
 
     [Theory]
@@ -70,17 +67,14 @@ public sealed class CreateCategoryHandlerTests
 
         // Assert
         result
-            .Should()
-            .NotBeNull();
+            .ShouldNotBeNull();
 
         result
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
 
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Invalid);
+            .ShouldBe(ResultStatus.Invalid);
     }
 }

--- a/tests/Dima.UnitTests/Api/Common/FluentValidationExtensions.cs
+++ b/tests/Dima.UnitTests/Api/Common/FluentValidationExtensions.cs
@@ -16,12 +16,9 @@ public class FluentValidationExtensions
         var errors = validationResult.AsErrors().ToArray();
 
         // Assert
-        errors.Should().NotBeNull();
         errors
-            .Should()
-            .ContainSingle()
-            .Which
-            .Should()
-            .BeEquivalentTo(new Error("Validation.Property.", "Error message"));
+            .ShouldNotBeNull();
+        errors
+            .ShouldContain(new Error("Validation.Property.", "Error message"));
     }
 }

--- a/tests/Dima.UnitTests/Core/Categories/CategoryTests.cs
+++ b/tests/Dima.UnitTests/Core/Categories/CategoryTests.cs
@@ -20,8 +20,7 @@ public class CategoryTests
         // Assert
         _testCategory
             .Title
-            .Should()
-            .Be(newTitle);
+            .ShouldBe(newTitle);
     }
 
     [Fact]
@@ -37,8 +36,7 @@ public class CategoryTests
         // Assert
         _testCategory
             .Description
-            .Should()
-            .Be(newDescription);
+            .ShouldBe(newDescription);
     }
 
     [Theory]
@@ -59,9 +57,7 @@ public class CategoryTests
 
         // Assert
         action
-            .Should()
-            .Throw<DomainException>()
-            .WithMessage(DomainErrors.Title.NullOrEmpty.ToString());
+            .ShouldThrow<DomainException>(DomainErrors.Title.NullOrEmpty.ToString());
     }
 
     [Theory]
@@ -75,9 +71,7 @@ public class CategoryTests
 
         // Assert
         action
-            .Should()
-            .Throw<DomainException>()
-            .WithMessage(DomainErrors.Title.NullOrEmpty.ToString());
+            .ShouldThrow<DomainException>(DomainErrors.Title.NullOrEmpty.ToString());
     }
 
     private Category CreateCategory()

--- a/tests/Dima.UnitTests/Core/Categories/DescriptionTests.cs
+++ b/tests/Dima.UnitTests/Core/Categories/DescriptionTests.cs
@@ -14,8 +14,7 @@ public class DescriptionTests
         Action action = () => _ = new Description(random.String());
 
         // Assert
-        action.Should()
-            .NotThrow<DomainException>();
+        action.ShouldNotThrow();
     }
 
     [Theory]
@@ -28,7 +27,9 @@ public class DescriptionTests
         var description = new Description(text!);
 
         // Assert
-        description.Text.Should().BeEmpty();
+        description
+            .Text
+            .ShouldBeEmpty();
     }
 
     [Fact]
@@ -41,9 +42,7 @@ public class DescriptionTests
         Action action = () => _ = new Description(random.String(Description.MaxLength + 1));
 
         // Assert
-        action.Should()
-            .Throw<DomainException>()
-            .WithMessage(DomainErrors.Description.LongerThanAllowed.ToString());
+        action.ShouldThrow<DomainException>(DomainErrors.Description.LongerThanAllowed.ToString());
     }
 
     [Fact]
@@ -57,7 +56,7 @@ public class DescriptionTests
         Description description = expected;
 
         // Assert
-        description.Text.Should().Be(expected);
+        description.Text.ShouldBe(expected);
     }
 
     [Theory]
@@ -71,7 +70,6 @@ public class DescriptionTests
 
         // Assert
         description.ToString()
-            .Should()
-            .Be(description.Text);
+            .ShouldBe(description.Text);
     }
 }

--- a/tests/Dima.UnitTests/Core/Categories/TitleTests.cs
+++ b/tests/Dima.UnitTests/Core/Categories/TitleTests.cs
@@ -16,7 +16,7 @@ public class TitleTests
         string result = title;
 
         // Assert
-        result.Should().Be(title.ToString());
+        result.ShouldBe(title.ToString());
     }
 
     [Fact]
@@ -29,8 +29,7 @@ public class TitleTests
         Action action = () => _ = new Title(random.String());
 
         // Assert
-        action.Should()
-            .NotThrow<DomainException>();
+        action.ShouldNotThrow();
     }
 
     [Fact]
@@ -43,9 +42,7 @@ public class TitleTests
         Action action = () => _ = new Title(random.String(Title.MaxLength + 1));
 
         // Assert
-        action.Should()
-            .Throw<DomainException>()
-            .WithMessage(DomainErrors.Title.LongerThanAllowed.ToString());
+        action.ShouldThrow<DomainException>(DomainErrors.Title.LongerThanAllowed.ToString());
     }
 
     [Theory]
@@ -57,9 +54,7 @@ public class TitleTests
         Action action = () => _ = new Title(text!);
 
         // Assert
-        action.Should()
-            .Throw<DomainException>()
-            .WithMessage(DomainErrors.Title.NullOrEmpty.ToString());
+        action.ShouldThrow<DomainException>(DomainErrors.Title.NullOrEmpty.ToString());
     }
 
     [Theory]
@@ -71,6 +66,7 @@ public class TitleTests
         var title = new Title(text!);
 
         // Assert
-        title.ToString().Should().Be(title.Value);
+        title.ToString()
+            .ShouldBe(title.Value);
     }
 }

--- a/tests/Dima.UnitTests/Core/Primitives/ErrorTests.cs
+++ b/tests/Dima.UnitTests/Core/Primitives/ErrorTests.cs
@@ -12,7 +12,7 @@ public class ErrorTests
         string code = error;
 
         // Assert
-        code.Should().Be(error.Code);
+        code.ShouldBe(error.Code);
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public class ErrorTests
         string result = error.ToString();
 
         // Assert
-        result.Should().Be(error.Message);
+        result.ShouldBe(error.Message);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class ErrorTests
         var error2 = new Error("Error.500", "Internal Server Error");
 
         // Act & Assert
-        error1.Should().NotBe(error2);
+        error1.ShouldNotBe(error2);
     }
 
     [Fact]
@@ -47,6 +47,6 @@ public class ErrorTests
         var error2 = new Error("error", "Error description");
 
         // Act & Assert
-        error1.Should().Be(error2);
+        error1.ShouldBe(error2);
     }
 }

--- a/tests/Dima.UnitTests/Core/Primitives/Result/ResultTTests.cs
+++ b/tests/Dima.UnitTests/Core/Primitives/Result/ResultTTests.cs
@@ -16,16 +16,13 @@ public class ResultTTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Created);
+            .ShouldBe(ResultStatus.Created);
         result
             .Value
-            .Should()
-            .Be(value);
+            .ShouldBe(value);
     }
 
     [Fact]
@@ -46,16 +43,13 @@ public class ResultTTests
         // Assert
         resultWithErrors
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
         resultWithErrors
             .Status
-            .Should()
-            .Be(result.Status);
+            .ShouldBe(result.Status);
         resultWithErrors
             .Errors
-            .Should()
-            .BeEquivalentTo(errors);
+            .ShouldBeEquivalentTo(errors);
     }
 
     [Fact]
@@ -70,16 +64,13 @@ public class ResultTTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Ok);
+            .ShouldBe(ResultStatus.Ok);
         result
             .Value
-            .Should()
-            .Be(value);
+            .ShouldBe(value);
     }
 
     [Fact]
@@ -94,16 +85,13 @@ public class ResultTTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Invalid);
+            .ShouldBe(ResultStatus.Invalid);
         result
             .Errors
-            .Should()
-            .ContainSingle(e => e == error);
+            .ShouldContain(e => e == error);
     }
 
     [Fact]
@@ -122,16 +110,13 @@ public class ResultTTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Invalid);
+            .ShouldBe(ResultStatus.Invalid);
         result
             .Errors
-            .Should()
-            .BeEquivalentTo(errors);
+            .ShouldBeEquivalentTo(errors);
     }
 
     [Fact]
@@ -143,16 +128,13 @@ public class ResultTTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.NoContent);
+            .ShouldBe(ResultStatus.NoContent);
         result
             .Errors
-            .Should()
-            .BeEmpty();
+            .ShouldBeEmpty();
     }
     [Fact]
     public void Success_ShouldHaveStatusOk()
@@ -166,16 +148,13 @@ public class ResultTTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Ok);
+            .ShouldBe(ResultStatus.Ok);
         result
             .Value
-            .Should()
-            .Be(value);
+            .ShouldBe(value);
     }
 
     [Fact]
@@ -189,9 +168,6 @@ public class ResultTTests
         Action action = () => _ = result.Value;
 
         // Assert
-        action
-            .Should()
-            .Throw<InvalidOperationException>()
-            .WithMessage("Cannot access value for a failure result.");
+        action.ShouldThrow<InvalidOperationException>();
     }
 }

--- a/tests/Dima.UnitTests/Core/Primitives/Result/ResultTests.cs
+++ b/tests/Dima.UnitTests/Core/Primitives/Result/ResultTests.cs
@@ -13,16 +13,13 @@ public class ResultTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Created);
+            .ShouldBe(ResultStatus.Created);
         result
             .Errors
-            .Should()
-            .BeEmpty();
+            .ShouldBeEmpty();
     }
 
     [Fact]
@@ -40,16 +37,13 @@ public class ResultTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Failure);
+            .ShouldBe(ResultStatus.Failure);
         result
             .Errors
-            .Should()
-            .BeEquivalentTo(errors);
+            .ShouldBeEquivalentTo(errors);
     }
 
     [Fact]
@@ -64,19 +58,14 @@ public class ResultTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Failure);
+            .ShouldBe(ResultStatus.Failure);
 
         result
             .Errors
-            .Should()
-            .ContainSingle().Which
-            .Should()
-            .BeEquivalentTo(error);
+            .ShouldContain(error);
     }
 
     [Fact]
@@ -94,16 +83,13 @@ public class ResultTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Invalid);
+            .ShouldBe(ResultStatus.Invalid);
         result
             .Errors
-            .Should()
-            .BeEquivalentTo(errors);
+            .ShouldBeEquivalentTo(errors);
     }
 
     [Fact]
@@ -118,18 +104,13 @@ public class ResultTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeFalse();
+            .ShouldBeFalse();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Invalid);
+            .ShouldBe(ResultStatus.Invalid);
         result
             .Errors
-            .Should()
-            .ContainSingle().Which
-            .Should()
-            .BeEquivalentTo(error);
+            .ShouldContain(error);
     }
 
     [Fact]
@@ -141,16 +122,13 @@ public class ResultTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.NoContent);
+            .ShouldBe(ResultStatus.NoContent);
         result
             .Errors
-            .Should()
-            .BeEmpty();
+            .ShouldBeEmpty();
     }
 
     [Fact]
@@ -162,15 +140,12 @@ public class ResultTests
         // Assert
         result
             .IsSuccess
-            .Should()
-            .BeTrue();
+            .ShouldBeTrue();
         result
             .Status
-            .Should()
-            .Be(ResultStatus.Ok);
+            .ShouldBe(ResultStatus.Ok);
         result
             .Errors
-            .Should()
-            .BeEmpty();
+            .ShouldBeEmpty();
     }
 }

--- a/tests/Dima.UnitTests/Dima.UnitTests.csproj
+++ b/tests/Dima.UnitTests/Dima.UnitTests.csproj
@@ -12,7 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -34,6 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Dima.UnitTests/GlobalUsings.cs
+++ b/tests/Dima.UnitTests/GlobalUsings.cs
@@ -1,5 +1,5 @@
 global using Bogus;
 global using Dima.Core.Primitives;
 global using Dima.Core.Primitives.Result;
-global using FluentAssertions;
 global using NSubstitute;
+global using Shouldly;


### PR DESCRIPTION
A licença de uso do pacote `FluentAssertions` foi alterada para uma licença comercial, apesar de de permitir o uso em projetos de código aberto, optou-se por substituir o pacote por `Shouldly`, que é uma biblioteca de asserções para testes de unidade, compatível com o `xUnit`, e é uma alternativa popular ao `FluentAssertions`.