### PR TITLE
feat: aplique os padrões Repository e Unit Of Work para lidar com persistência de dados 

### DIFF
--- a/src/Dima.Api/Categories/CreateCategory/CreateCategoryHandler.cs
+++ b/src/Dima.Api/Categories/CreateCategory/CreateCategoryHandler.cs
@@ -6,11 +6,11 @@ using FluentValidation;
 namespace Dima.Api.Categories.CreateCategory;
 
 /// <summary>
-/// Handles the creation of a new category.
+/// Handles the creation of a new <see cref="Category"/>.
 /// </summary>
 /// <remarks>
 /// This handler validates the incoming <see cref="CreateCategoryRequest"/>, creates a new <see cref="Category"/> entity,
-/// persists it to the database, and returns the ID of the created category.
+/// persists it to the database using the provided <see cref="ICategoryRepository"/>, and returns the ID of the created category.
 /// </remarks>
 /// <param name="repository">The category repository used to persist the new category.</param>
 /// <param name="validator">The validator for the create category request.</param>
@@ -22,8 +22,8 @@ internal sealed class CreateCategoryHandler(
     /// <summary>
     /// Handles the create category request asynchronously.
     /// </summary>
-    /// <param name="request">The create category request.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="request">The create category request containing the data for the new category.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
     /// <returns>
     /// A <see cref="Result{T}"/> containing the ID of the created category if successful,
     /// or validation errors if the request is invalid.

--- a/src/Dima.Api/Categories/CreateCategory/CreateCategoryHandler.cs
+++ b/src/Dima.Api/Categories/CreateCategory/CreateCategoryHandler.cs
@@ -12,10 +12,10 @@ namespace Dima.Api.Categories.CreateCategory;
 /// This handler validates the incoming <see cref="CreateCategoryRequest"/>, creates a new <see cref="Category"/> entity,
 /// persists it to the database, and returns the ID of the created category.
 /// </remarks>
-/// <param name="context">The application database context.</param>
+/// <param name="repository">The category repository used to persist the new category.</param>
 /// <param name="validator">The validator for the create category request.</param>
 internal sealed class CreateCategoryHandler(
-    IApplicationDbContext context,
+    ICategoryRepository repository,
     IValidator<CreateCategoryRequest> validator)
     : ICreateCategoryHandler
 {
@@ -48,8 +48,10 @@ internal sealed class CreateCategoryHandler(
         var category = new Category(title);
         category.ChangeDescription(request.Description);
 
-        await context.Categories.AddAsync(category, cancellationToken);
-        await context.SaveChangesAsync(cancellationToken);
+        await repository.AddAsync(category, cancellationToken);
+        _ = await repository
+            .UnitOfWork
+            .SaveChangesAsync(cancellationToken);
 
         return Result<long>.Created(category.Id);
     }

--- a/src/Dima.Api/Data/Categories/CategoryRepository.cs
+++ b/src/Dima.Api/Data/Categories/CategoryRepository.cs
@@ -1,0 +1,13 @@
+using Dima.Core.Categories;
+
+namespace Dima.Api.Data.Categories;
+
+/// <inheritdoc cref="ICategoryRepository" />
+public class CategoryRepository(DimaDbContext context)
+    : ICategoryRepository
+{
+    public IUnitOfWork UnitOfWork => context;
+
+    public async Task AddAsync(Category category, CancellationToken cancellationToken = default)
+        => await context.Categories.AddAsync(category, cancellationToken);
+}

--- a/src/Dima.Api/Data/Categories/CategoryRepository.cs
+++ b/src/Dima.Api/Data/Categories/CategoryRepository.cs
@@ -1,4 +1,5 @@
 using Dima.Core.Categories;
+using Microsoft.EntityFrameworkCore;
 
 namespace Dima.Api.Data.Categories;
 
@@ -9,5 +10,23 @@ public class CategoryRepository(DimaDbContext context)
     public IUnitOfWork UnitOfWork => context;
 
     public async Task AddAsync(Category category, CancellationToken cancellationToken = default)
-        => await context.Categories.AddAsync(category, cancellationToken);
+        => await context
+            .Categories
+            .AddAsync(
+                category,
+                cancellationToken
+            );
+
+    public async Task<Category?> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+        => await context
+            .Categories
+            .SingleOrDefaultAsync(
+                c => c.Id == id,
+                cancellationToken
+            );
+
+    public void Update(Category category)
+        => context
+            .Categories
+            .Update(category);
 }

--- a/src/Dima.Api/Data/DependencyInjection.cs
+++ b/src/Dima.Api/Data/DependencyInjection.cs
@@ -5,16 +5,18 @@ using Microsoft.EntityFrameworkCore;
 namespace Dima.Api.Data;
 
 /// <summary>
-/// Contains the dependency injection extensions.
+/// Contains extension methods for registering persistence and repository services in the dependency injection container.
 /// </summary>
 public static class DependencyInjection
 {
     /// <summary>
-    /// Adds the persistence data.
+    /// Adds persistence-related services to the specified <see cref="IServiceCollection"/>, including the database context and repositories.
     /// </summary>
-    /// <param name="services">The collection of service descriptors.</param>
-    /// <param name="configuration">The application configuration properties.</param>
-    /// <returns>Returns the updated service collection.</returns>
+    /// <param name="services">The collection of service descriptors to which persistence services will be added.</param>
+    /// <param name="configuration">The application configuration properties used to retrieve the connection string.</param>
+    /// <returns>
+    /// The updated <see cref="IServiceCollection"/> with persistence services registered.
+    /// </returns>
     public static IServiceCollection AddPersistence(this IServiceCollection services, IConfiguration configuration)
     {
         var connectionString = configuration.GetConnectionString(ConnectionString.DefaultConnection)!;

--- a/src/Dima.Api/Data/DependencyInjection.cs
+++ b/src/Dima.Api/Data/DependencyInjection.cs
@@ -1,3 +1,5 @@
+using Dima.Api.Data.Categories;
+using Dima.Core.Categories;
 using Microsoft.EntityFrameworkCore;
 
 namespace Dima.Api.Data;
@@ -21,7 +23,21 @@ public static class DependencyInjection
         services.AddDbContext<DimaDbContext>(options =>
             options.UseNpgsql(connectionString));
 
-        services.AddScoped<IApplicationDbContext>(sp => sp.GetRequiredService<DimaDbContext>());
+        services.AddRepositories();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers repository services in the specified <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The collection of service descriptors to which repository services will be added.</param>
+    /// <returns>
+    /// The updated <see cref="IServiceCollection"/> with repository services registered.
+    /// </returns>
+    private static IServiceCollection AddRepositories(this IServiceCollection services)
+    {
+        services.AddScoped<ICategoryRepository, CategoryRepository>();
 
         return services;
     }

--- a/src/Dima.Api/Data/DimaDbContext.cs
+++ b/src/Dima.Api/Data/DimaDbContext.cs
@@ -10,7 +10,7 @@ namespace Dima.Api.Data;
 /// <param name="options">The database context options</param>
 public class DimaDbContext(DbContextOptions<DimaDbContext> options)
     : DbContext(options),
-    IApplicationDbContext
+    IUnitOfWork
 {
     public DbSet<Category> Categories => Set<Category>();
 

--- a/src/Dima.Core/Categories/ICategoryRepository.cs
+++ b/src/Dima.Core/Categories/ICategoryRepository.cs
@@ -4,7 +4,7 @@ namespace Dima.Core.Categories;
 /// Defines a contract for a repository that manages <see cref="Category"/> entities.
 /// </summary>
 /// <remarks>
-/// Provides methods to interact with the category data store, including adding new categories.
+/// Provides methods to interact with the category data store, including adding, retrieving, and updating categories.
 /// Inherits from <see cref="IRepository"/> to support unit of work and transaction management.
 /// </remarks>
 public interface ICategoryRepository : IRepository
@@ -18,4 +18,20 @@ public interface ICategoryRepository : IRepository
     /// A <see cref="Task"/> that represents the asynchronous add operation.
     /// </returns>
     Task AddAsync(Category category, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves a <see cref="Category"/> by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the category.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> whose result is the <see cref="Category"/> if found; otherwise, <c>null</c>.
+    /// </returns>
+    Task<Category?> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the specified <see cref="Category"/> in the data store.
+    /// </summary>
+    /// <param name="category">The <see cref="Category"/> entity to update.</param>
+    void Update(Category category);
 }

--- a/src/Dima.Core/Categories/ICategoryRepository.cs
+++ b/src/Dima.Core/Categories/ICategoryRepository.cs
@@ -1,0 +1,21 @@
+namespace Dima.Core.Categories;
+
+/// <summary>
+/// Defines a contract for a repository that manages <see cref="Category"/> entities.
+/// </summary>
+/// <remarks>
+/// Provides methods to interact with the category data store, including adding new categories.
+/// Inherits from <see cref="IRepository"/> to support unit of work and transaction management.
+/// </remarks>
+public interface ICategoryRepository : IRepository
+{
+    /// <summary>
+    /// Asynchronously adds a new <see cref="Category"/> to the data store.
+    /// </summary>
+    /// <param name="category">The <see cref="Category"/> entity to add.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// A <see cref="Task"/> that represents the asynchronous add operation.
+    /// </returns>
+    Task AddAsync(Category category, CancellationToken cancellationToken = default);
+}

--- a/src/Dima.Core/Primitives/IRepository.cs
+++ b/src/Dima.Core/Primitives/IRepository.cs
@@ -1,0 +1,17 @@
+namespace Dima.Core.Primitives;
+
+/// <summary>
+/// Defines a contract for a repository that provides access to a collection of entities and is associated with a unit of work.
+/// </summary>
+/// <remarks>
+/// This interface should be implemented by repositories that manage entities and coordinate changes
+/// through a unit of work. Implementations are expected to provide methods for querying and manipulating
+/// entities, ensuring that all changes are tracked and persisted as part of the associated <see cref="IUnitOfWork"/>.
+/// </remarks>
+public interface IRepository
+{
+    /// <summary>
+    /// Gets the current <see cref="IUnitOfWork"/> instance used to manage database transactions and operations.
+    /// </summary>
+    public IUnitOfWork UnitOfWork { get; }
+}

--- a/src/Dima.Core/Primitives/IUnitOfWork.cs
+++ b/src/Dima.Core/Primitives/IUnitOfWork.cs
@@ -1,0 +1,24 @@
+namespace Dima.Core.Primitives;
+
+/// <summary>
+/// Represents a unit of work that encapsulates a set of operations to be committed as a single transaction.
+/// </summary>
+/// <remarks>
+/// This interface is typically used to coordinate changes across multiple repositories or data sources,
+/// ensuring that all changes are saved atomically. Implementations should handle transaction management
+/// and ensure data consistency.
+/// </remarks>
+public interface IUnitOfWork : IDisposable
+{
+    /// <summary>
+    /// Asynchronously saves all changes made in the current context to the underlying database.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// A <see cref="CancellationToken"/> that can be used to cancel the asynchronous save operation.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the asynchronous save operation. The task result contains
+    /// the number of state entries written to the database.
+    /// </returns>
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/tests/Dima.UnitTests/Api/Categories/CreateCategoryHandlerTests.cs
+++ b/tests/Dima.UnitTests/Api/Categories/CreateCategoryHandlerTests.cs
@@ -1,5 +1,5 @@
 using Dima.Api.Categories.CreateCategory;
-using Dima.Api.Data;
+using Dima.Core.Categories;
 using Dima.Core.Categories.CreateCategory;
 using FluentValidation;
 
@@ -13,11 +13,11 @@ public sealed class CreateCategoryHandlerTests
     public CreateCategoryHandlerTests()
     {
         _cancellationToken = TestContext.Current.CancellationToken;
-        IApplicationDbContext context = Substitute.For<IApplicationDbContext>();
+        ICategoryRepository repository = Substitute.For<ICategoryRepository>();
         IValidator<CreateCategoryRequest> validator = new CreateCategoryRequestValidator();
 
         _handler = new CreateCategoryHandler(
-            context,
+            repository,
             validator);
     }
 

--- a/tests/Dima.UnitTests/Api/Categories/CreateCategoryHandlerTests.cs
+++ b/tests/Dima.UnitTests/Api/Categories/CreateCategoryHandlerTests.cs
@@ -9,15 +9,15 @@ public sealed class CreateCategoryHandlerTests
 {
     private readonly CancellationToken _cancellationToken;
     private readonly CreateCategoryHandler _handler;
+    private readonly ICategoryRepository _repositoryMock = Substitute.For<ICategoryRepository>();
 
     public CreateCategoryHandlerTests()
     {
         _cancellationToken = TestContext.Current.CancellationToken;
-        ICategoryRepository repository = Substitute.For<ICategoryRepository>();
         IValidator<CreateCategoryRequest> validator = new CreateCategoryRequestValidator();
 
         _handler = new CreateCategoryHandler(
-            repository,
+            _repositoryMock,
             validator);
     }
 
@@ -28,6 +28,11 @@ public sealed class CreateCategoryHandlerTests
         var createCategoryRequest = new CreateCategoryRequest(
             "Category title",
             "Category description");
+
+        _repositoryMock
+            .UnitOfWork
+            .SaveChangesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(1));
 
         // Act
         var result = await _handler.HandleAsync(
@@ -45,6 +50,15 @@ public sealed class CreateCategoryHandlerTests
         result
             .Status
             .ShouldBe(ResultStatus.Created);
+
+        await _repositoryMock
+            .Received(1)
+            .AddAsync(Arg.Any<Category>(), Arg.Any<CancellationToken>());
+
+        await _repositoryMock
+            .UnitOfWork
+            .Received(1)
+            .SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -76,5 +90,9 @@ public sealed class CreateCategoryHandlerTests
         result
             .Status
             .ShouldBe(ResultStatus.Invalid);
+
+        await _repositoryMock
+            .DidNotReceive()
+            .AddAsync(Arg.Any<Category>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Dima.UnitTests/Api/Categories/UpdateCategoryHandlerTests.cs
+++ b/tests/Dima.UnitTests/Api/Categories/UpdateCategoryHandlerTests.cs
@@ -1,0 +1,113 @@
+using Dima.Api.Categories.UpdateCategory;
+using Dima.Core.Categories;
+using Dima.Core.Categories.UpdateCategory;
+
+namespace Dima.UnitTests.Api.Categories;
+
+public class UpdateCategoryHandlerTests
+{
+    private readonly CancellationToken _cancellationToken;
+    private readonly UpdateCategoryHandler _handler;
+    private readonly ICategoryRepository _repositoryMock = Substitute.For<ICategoryRepository>();
+
+    public UpdateCategoryHandlerTests()
+    {
+        var validator = new UpdateCategoryRequestValidator();
+        _cancellationToken = TestContext.Current.CancellationToken;
+        _handler = new UpdateCategoryHandler(
+            _repositoryMock,
+            validator
+        );
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldReturnInvalid_WhenValidationFails()
+    {
+        // Arrange
+        var request = new UpdateCategoryRequest(1, "", "Desc");
+
+        // Act
+        var result = await _handler.HandleAsync(request, _cancellationToken);
+
+        // Assert
+        result
+            .ShouldNotBeNull();
+
+        result
+            .IsSuccess
+            .ShouldBeFalse();
+
+        result
+            .Status
+            .ShouldBe(ResultStatus.Invalid);
+
+        await _repositoryMock
+            .DidNotReceive()
+            .GetByIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldReturnNotFound_WhenCategoryDoesNotExist()
+    {
+        // Arrange
+        var request = new UpdateCategoryRequest(1, "Test", "Desc");
+
+        _repositoryMock.GetByIdAsync(request.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Category?>(null));
+
+        // Act
+        var result = await _handler.HandleAsync(request, _cancellationToken);
+
+        // Assert
+        result
+            .ShouldNotBeNull();
+
+        result
+            .IsSuccess
+            .ShouldBeFalse();
+
+        result
+            .Status
+            .ShouldBe(ResultStatus.NotFound);
+
+        _repositoryMock
+        .DidNotReceive()
+        .Update(Arg.Any<Category>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldUpdateCategory_WhenRequestIsValid()
+    {
+        // Arrange
+        var request = new UpdateCategoryRequest(1, "New Title", "New Desc");
+        var category = new Category(new Title("Old Title"));
+        _repositoryMock.GetByIdAsync(request.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Category?>(category));
+        _repositoryMock.UnitOfWork.SaveChangesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(1));
+
+        // Act
+        var result = await _handler.HandleAsync(request, _cancellationToken);
+
+        // Assert
+        result
+            .ShouldNotBeNull();
+
+        result
+            .IsSuccess
+            .ShouldBeTrue();
+
+        result
+            .Status
+            .ShouldBe(ResultStatus.NoContent);
+
+        _repositoryMock
+        .Received(1)
+        .Update(category);
+
+        await _repositoryMock
+        .UnitOfWork
+        .Received(1)
+        .SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Introduzido o uso do _Repository Pattern_  e _Unit Of Work_ para lidar com persistência de dados e permitir que os testes de unidade sejam realizados com mais facilidade.